### PR TITLE
Proper use of included Facade.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,6 +30,14 @@ And add the service provider to your application.
 ...
 ```
 
+```
+...
+'aliases' => [
+    '...',
+    'Elm' => Tightenco\Elm\ElmFacade::class,
+];
+```
+
 When this provider is booted, you'll gain access to a helpful `Elm` facade, which you may use in your controllers.
 
 ```php

--- a/readme.md
+++ b/readme.md
@@ -13,12 +13,12 @@ Begin by installing this package through Composer.
 ```js
 {
     "require": {
-		"tightenco/laravel-elm": "~1.0"
-	}
+        "tightenco/laravel-elm": "~1.0"
+    }
 }
 ```
 
-And add the service provider to your application.
+And add the service provider and facade alias to your application config.
 
 **config/app.php**
 ```
@@ -38,7 +38,7 @@ And add the service provider to your application.
 ];
 ```
 
-When this provider is booted, you'll gain access to a helpful `Elm` facade, which you may use in your controllers.
+You may then use the helpful `Elm` facade in your controllers.
 
 ```php
 use Elm;

--- a/src/ElmServiceProvider.php
+++ b/src/ElmServiceProvider.php
@@ -34,6 +34,6 @@ class ElmServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        class_alias('Tightenco\Elm\ElmFacade', 'Elm');
+        //
     }
 }


### PR DESCRIPTION
Using `class_alias` causes an `[ErrorException]` when attempting to cache the application configuration (`php artisan config:cache`).

It removes the call to `class_alias` from the service provider, preferring the proper use of the included Facade. It also updates the readme accordingly.